### PR TITLE
Fix k9s binary path post 0.24.10

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -208,6 +208,14 @@ get_filename_pre_0_14_0() {
   echo "${binary_name}_${version}_${platform}.tar.gz"
 }
 
+get_filename_post_0_24_10() {
+  local version="$1"
+  local platform="$2"
+  local binary_name="$3"
+
+  echo "${binary_name}_v${version}_${platform}.tar.gz"
+}
+
 k9s_get_download_url() {
   local version="$1"
   local platform="$2"
@@ -238,6 +246,19 @@ k9s_get_download_url() {
   if [[ "$op" == '<' ]]; then
     path_version="$version"
   else
+    path_version="v$version"
+  fi
+
+  vercomp "$version" "0.24.10"
+  case $? in
+  0) op='=' ;;
+  1) op='>' ;;
+  2) op='<' ;;
+  esac
+  if [[ "$op" == '<' ]]; then
+    : # do not alter behavior
+  else
+    filename="$(get_filename_post_0_24_10 "$version" "$platform" "$binary_name")"
     path_version="v$version"
   fi
 


### PR DESCRIPTION
K9s repository changed the archives' naming scheme again with version 0.24.10. This PR fixes `asdf`'s inability to download those archives. Fixes #18 