### PR TITLE
fix(installer): don't shadow `btm` binary

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -11,7 +11,6 @@ readonly NO_BINARY_ALTNAME=@@UNDEFINED@@
 # shellcheck disable=SC2034
 readonly g_github_coordinates=derailed/k9s
 readonly g_binary_name=k9s
-readonly g_binary_altname=btm
 #
 # available : __VERSION__/__VERSION_SHORT__/__BINARY_NAME__/__PLATFORM__
 #


### PR DESCRIPTION
This change prevents the creation of an alternatte binary named `btm`. 
`btm` is a binary installed by https://github.com/ClementTsang/bottom, which is shadowed by this `asdf` plugin.

I think this might have been added by accident, as `btm` is completely [unrelated to the k9s project](https://github.com/derailed/k9s/search?q=btm). 