### PR TITLE
ci(wf): enforce asdf v0.15.0 as v0.16.0 is a real nightmare for plugin testing

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -23,20 +23,20 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: asdf_plugin_test default
-        uses: asdf-vm/actions/plugin-test@v3
-        with:
-          command: k9s --help
-
       - name: Checkout code
         uses: actions/checkout@v4
 
+#      - name: asdf_plugin_test default
+#        uses: asdf-vm/actions/plugin-test@master
+#        with:
+#          command: k9s --help
+
       - name: Install Tools with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@master
 
       - name: Test plugin with bats
         run: |
-          asdf plugin-add k9s "${GITHUB_WORKSPACE}"
+          asdf plugin add k9s "${GITHUB_WORKSPACE}"
           bats --filter-tags type:features --filter-tags type:os_specific test
 
   lint_and_tests:
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Tools with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@master
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -23,20 +23,23 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: asdf_plugin_test default
+        uses: asdf-vm/actions/plugin-test@v3
+        with:
+          asdf_branch: v0.15.0
+          command: k9s --help
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-#      - name: asdf_plugin_test default
-#        uses: asdf-vm/actions/plugin-test@master
-#        with:
-#          command: k9s --help
-
       - name: Install Tools with asdf
-        uses: asdf-vm/actions/install@master
+        uses: asdf-vm/actions/install@v3
+        with:
+          asdf_branch: v0.15.0
 
       - name: Test plugin with bats
         run: |
-          asdf plugin add k9s "${GITHUB_WORKSPACE}"
+          asdf plugin-add k9s "${GITHUB_WORKSPACE}"
           bats --filter-tags type:features --filter-tags type:os_specific test
 
   lint_and_tests:
@@ -46,7 +49,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Tools with asdf
-        uses: asdf-vm/actions/install@master
+        uses: asdf-vm/actions/install@v3
+        with:
+          asdf_branch: v0.15.0
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
# Description

## What this PR Provides

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Chore (gha, tools, pre-commit)
- [ ] Tests

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
